### PR TITLE
Feat  hw publisher

### DIFF
--- a/odrive_ros2_control/CMakeLists.txt
+++ b/odrive_ros2_control/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(rclcpp REQUIRED)
 find_package(ament_cmake_auto REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(osc_utils REQUIRED)
+find_package(osc_interfaces REQUIRED)
 ament_auto_find_build_dependencies()
 
 ament_export_dependencies(rosidl_default_runtime std_msgs osc_utils)

--- a/odrive_ros2_control/CMakeLists.txt
+++ b/odrive_ros2_control/CMakeLists.txt
@@ -9,12 +9,19 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(ament_cmake_auto REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(osc_utils REQUIRED)
 ament_auto_find_build_dependencies()
 
-ament_export_dependencies(rosidl_default_runtime)
+ament_export_dependencies(rosidl_default_runtime std_msgs osc_utils)
+
 
 include_directories(include)
 include_directories(../odrive_base/include)
+include_directories(
+  ${osc_utils_INCLUDE_DIRS}
+)
+
 
 ament_auto_add_library(
   odrive_ros2_control_plugin SHARED
@@ -25,8 +32,17 @@ ament_auto_add_library(
 
 ament_target_dependencies(odrive_ros2_control_plugin
   rclcpp
+  std_msgs
+  osc_utils
 )
 
+target_link_libraries(odrive_ros2_control_plugin ${osc_utils_LIBRARIES})
+
+target_include_directories(
+  odrive_ros2_control_plugin
+  PRIVATE
+  ${osc_utils_INCLUDE_DIRS}
+)
 pluginlib_export_plugin_description_file(hardware_interface odrive_hardware_interface.xml)
 
 target_compile_features(odrive_ros2_control_plugin PRIVATE cxx_std_20)
@@ -35,6 +51,13 @@ install(TARGETS odrive_ros2_control_plugin
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
+)
+
+ament_export_include_directories(
+  include
+)
+ament_export_libraries(
+  odrive_ros2_control_plugin
 )
 
 ament_package()

--- a/odrive_ros2_control/package.xml
+++ b/odrive_ros2_control/package.xml
@@ -13,6 +13,8 @@
 
   <depend>rclcpp</depend>
   <depend>hardware_interface</depend>
+  <depend>osc_interfaces</depend>
+  <depend>osc_utils</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/odrive_ros2_control/src/odrive_hardware_interface.cpp
+++ b/odrive_ros2_control/src/odrive_hardware_interface.cpp
@@ -398,10 +398,10 @@ osc_interfaces::msg::MotorState ODriveHardwareInterface::generate_motor_state_ms
     for (auto& axis : axes_) {
         msg.uid.push_back(std::to_string(axis.serial_number_));
 
-        msg.bus_voltage.push_back(axis.bus_voltage_);
-        msg.bus_current.push_back(axis.bus_current_);
-        msg.computed_torque.push_back(axis.torque_estimate_);
-        msg.motor_temperature.push_back(axis.motor_temperature_);
+        msg.bus_voltage_v.push_back(axis.bus_voltage_);
+        msg.bus_current_ma.push_back(axis.bus_current_);
+        msg.computed_torque_nm.push_back(axis.torque_estimate_);
+        msg.motor_temperature_c.push_back(axis.motor_temperature_);
 
         msg.connection_motor_error.push_back(axis.connection_error_);
         if (axis.error_code_ != ODRIVE_ERROR_NONE) {

--- a/odrive_ros2_control/src/odrive_hardware_interface.cpp
+++ b/odrive_ros2_control/src/odrive_hardware_interface.cpp
@@ -258,7 +258,8 @@ return_type ODriveHardwareInterface::perform_command_mode_switch(
         std::array<std::pair<std::string, bool*>, 3> interfaces = {
             {{info_.joints[i].name + "/" + hardware_interface::HW_IF_POSITION, &axis.pos_input_enabled_},
              {info_.joints[i].name + "/" + hardware_interface::HW_IF_VELOCITY, &axis.vel_input_enabled_},
-             {info_.joints[i].name + "/" + hardware_interface::HW_IF_EFFORT, &axis.torque_input_enabled_}}};
+             {info_.joints[i].name + "/" + hardware_interface::HW_IF_EFFORT, &axis.torque_input_enabled_}}
+        };
 
         bool mode_switch = false;
 
@@ -295,11 +296,11 @@ return_type ODriveHardwareInterface::read(const rclcpp::Time& timestamp, const r
         // repeat until CAN interface has no more messages
     }
     osc_interfaces::msg::OdriveMotorState msg;
-    
-    for (int axis_id;axis_id<axes_.size();axis_id++){
-        msg.vbus_voltage[axis_id] = axes_[axis_id].bus_voltage_;
-        msg.ibus[axis_id] = axes_[axis_id].bus_current_;
-        msg.torque_estimate[axis_id] = axes_[axis_id].torque_estimate_;
+
+    for (auto& axis:axes_) {
+        msg.vbus_voltage.push_back(axis.bus_voltage_);
+        msg.ibus.push_back(axis.bus_current_);
+        msg.torque_estimate.push_back(axis.torque_estimate_);
     }
     pub_->publishData(msg);
     return return_type::OK;

--- a/odrive_ros2_control/src/odrive_hardware_interface.cpp
+++ b/odrive_ros2_control/src/odrive_hardware_interface.cpp
@@ -158,7 +158,7 @@ CallbackReturn ODriveHardwareInterface::on_init(const hardware_interface::Hardwa
             axis.direction_multiplier_ = 1.0;
         }
     }
-    pub_ = std::make_shared<SimplePublisher<osc_interfaces::msg::MotorState>>("NodeDynamixelState", "OdrvState");
+    pub_ = std::make_shared<SimplePublisher<osc_interfaces::msg::MotorState>>("NodeDynamixelState", "OdriveState");
     return CallbackReturn::SUCCESS;
 }
 

--- a/odrive_ros2_control/src/odrive_hardware_interface.cpp
+++ b/odrive_ros2_control/src/odrive_hardware_interface.cpp
@@ -49,8 +49,8 @@ private:
     std::string can_intf_name_;
     SocketCanIntf can_intf_;
     rclcpp::Time timestamp_;
-    rclcpp::Time timestamp_pub_;
-    osc_interfaces::msg::MotorState generate_motor_state_message(const rclcpp::Time &  now);
+    rclcpp::Time timestamp_pub_{rclcpp::Clock().now()};
+    osc_interfaces::msg::MotorState generate_motor_state_msg(const rclcpp::Time &  now);
     std::string get_error_string(uint32_t error_code);
     std::shared_ptr<SimplePublisher<osc_interfaces::msg::MotorState>> pub_;
 };
@@ -307,7 +307,7 @@ return_type ODriveHardwareInterface::read(const rclcpp::Time& timestamp, const r
         // repeat until CAN interface has no more messages
     }
     if ((timestamp_.seconds() - timestamp_pub_.seconds()) > MOTOR_STATE_PUBLISH_TIMEOUT_S) {
-        osc_interfaces::msg::MotorState msg = generate_motor_state_message(timestamp);
+        osc_interfaces::msg::MotorState msg = generate_motor_state_msg(timestamp);
         pub_->publishData(msg);
         timestamp_pub_ = timestamp_;
     }
@@ -388,7 +388,8 @@ void ODriveHardwareInterface::set_axis_command_mode(const Axis& axis) {
     axis.send(clear_error_msg);
     axis.send(state_msg);
 }
-osc_interfaces::msg::MotorState ODriveHardwareInterface::generate_motor_state_message(const rclcpp::Time &  now) {
+
+osc_interfaces::msg::MotorState ODriveHardwareInterface::generate_motor_state_msg(const rclcpp::Time &  now) {
     osc_interfaces::msg::MotorState msg;
     msg.header.stamp = now;
     msg.motor_type = osc_interfaces::msg::MotorState::MOTOR_TYPE_PROP;

--- a/odrive_ros2_control/src/odrive_hardware_interface.cpp
+++ b/odrive_ros2_control/src/odrive_hardware_interface.cpp
@@ -295,10 +295,11 @@ return_type ODriveHardwareInterface::read(const rclcpp::Time& timestamp, const r
         // repeat until CAN interface has no more messages
     }
     osc_interfaces::msg::OdriveMotorState msg;
-    for (auto& axis : axes_) {
-        msg.vbus_voltage = axis.bus_voltage_;
-        msg.ibus = axis.bus_current_;
-        msg.torque_estimate = axis.torque_estimate_;
+    
+    for (int axis_id;axis_id<axes_.size();axis_id++){
+        msg.vbus_voltage[axis_id] = axes_[axis_id].bus_voltage_;
+        msg.ibus[axis_id] = axes_[axis_id].bus_current_;
+        msg.torque_estimate[axis_id] = axes_[axis_id].torque_estimate_;
     }
     pub_->publishData(msg);
     return return_type::OK;

--- a/odrive_ros2_control/src/odrive_hardware_interface.cpp
+++ b/odrive_ros2_control/src/odrive_hardware_interface.cpp
@@ -89,7 +89,6 @@ struct Axis {
     double bus_current_ = NAN;
     double direction_multiplier_ = 1.0;
 
-    double serial_number_ = NAN;
     // Indicates which controller inputs are enabled. This is configured by the
     // controller that sits on top of this hardware interface. Multiple inputs
     // can be enabled at the same time, in this case the non-primary inputs are
@@ -398,7 +397,7 @@ osc_interfaces::msg::MotorState ODriveHardwareInterface::generate_motor_state_ms
     msg.motor_type = osc_interfaces::msg::MotorState::MOTOR_TYPE_PROP;
 
     for (auto& axis : axes_) {
-        msg.uid.push_back(std::to_string(axis.serial_number_));
+        msg.uid.push_back(static_cast<uint8_t>(axis.node_id_));
 
         msg.bus_voltage_v.push_back(axis.bus_voltage_);
         msg.bus_current_ma.push_back(axis.bus_current_ * 1000);
@@ -532,11 +531,6 @@ void Axis::on_can_msg(const rclcpp::Time& timestamp, const can_frame& frame) {
         case Get_Temperature_msg_t::cmd_id: {
             if (Get_Temperature_msg_t msg; try_decode(msg)) {
                 motor_temperature_ = msg.Motor_Temperature;
-            }
-        } break;
-        case Address_msg_t::cmd_id: {
-            if (Address_msg_t msg; try_decode(msg)) {
-                serial_number_ = msg.Serial_Number;
             }
         } break;
         case Heartbeat_msg_t::cmd_id: {

--- a/odrive_ros2_control/src/odrive_hardware_interface.cpp
+++ b/odrive_ros2_control/src/odrive_hardware_interface.cpp
@@ -51,6 +51,7 @@ private:
     rclcpp::Time timestamp_;
     rclcpp::Time timestamp_pub_;
     osc_interfaces::msg::MotorState generate_motor_state_message(const rclcpp::Time &  now);
+    std::string get_error_string(uint32_t error_code);
     std::shared_ptr<SimplePublisher<osc_interfaces::msg::MotorState>> pub_;
 };
 
@@ -99,7 +100,7 @@ struct Axis {
     bool vel_input_enabled_ = false;
     bool torque_input_enabled_ = false;
 
-    double error_code_ = ODRIVE_ERROR_NONE;
+    uint32_t error_code_ = ODRIVE_ERROR_NONE;
     double connection_error_ = osc_interfaces::msg::MotorState::MOTOR_CONNECTION_ERROR_NONE;
 
     rclcpp::Time timestamp_heartbeat_ = rclcpp::Time(0);
@@ -393,7 +394,7 @@ osc_interfaces::msg::MotorState ODriveHardwareInterface::generate_motor_state_me
     msg.motor_type = osc_interfaces::msg::MotorState::MOTOR_TYPE_PROP;
 
     for (auto& axis : axes_) {       
-        msg.serial_number.push_back(std::to_string(axis.serial_number_)); 
+        msg.uid.push_back(std::to_string(axis.serial_number_)); 
 
         msg.bus_voltage.push_back(axis.bus_voltage_);
         msg.bus_current.push_back(axis.bus_current_);
@@ -433,7 +434,7 @@ osc_interfaces::msg::MotorState ODriveHardwareInterface::generate_motor_state_me
     return msg;
 }
 
-std::string get_error_string(uint32_t error_code) {
+std::string ODriveHardwareInterface::get_error_string(uint32_t error_code) {
     if (error_code == ODRIVE_ERROR_NONE) {
         return "OK";
     }

--- a/odrive_ros2_control/src/odrive_hardware_interface.cpp
+++ b/odrive_ros2_control/src/odrive_hardware_interface.cpp
@@ -5,7 +5,7 @@
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 #include "odrive_enums.h"
 #include "osc_interfaces/msg/motor_state.hpp"
-#include "osc_utils/hw_publisher.hpp"
+#include "osc_utils/simple_publisher.hpp"
 #include "pluginlib/class_list_macros.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "socket_can.hpp"
@@ -47,7 +47,7 @@ private:
     SocketCanIntf can_intf_;
     rclcpp::Time timestamp_;
     osc_interfaces::msg::MotorState generate_motor_state_message(const rclcpp::Time &  now);
-    std::shared_ptr<HwPublisher<osc_interfaces::msg::MotorState>> pub_;
+    std::shared_ptr<SimplePublisher<osc_interfaces::msg::MotorState>> pub_;
 };
 
 struct Axis {
@@ -156,7 +156,7 @@ CallbackReturn ODriveHardwareInterface::on_init(const hardware_interface::Hardwa
             axis.direction_multiplier_ = 1.0;
         }
     }
-    pub_ = std::make_shared<HwPublisher<osc_interfaces::msg::MotorState>>("NodeDynamixelState", "OdrvState");
+    pub_ = std::make_shared<SimplePublisher<osc_interfaces::msg::MotorState>>("NodeDynamixelState", "OdrvState");
     return CallbackReturn::SUCCESS;
 }
 

--- a/odrive_ros2_control/src/odrive_hardware_interface.cpp
+++ b/odrive_ros2_control/src/odrive_hardware_interface.cpp
@@ -156,7 +156,7 @@ CallbackReturn ODriveHardwareInterface::on_init(const hardware_interface::Hardwa
             axis.direction_multiplier_ = 1.0;
         }
     }
-    pub_ = std::make_shared<HwPublisher<osc_interfaces::msg::MotorState>>("odrv_pub_node", "odrv_publisher");
+    pub_ = std::make_shared<HwPublisher<osc_interfaces::msg::MotorState>>("NodeDynamixelState", "OdrvState");
     return CallbackReturn::SUCCESS;
 }
 

--- a/odrive_ros2_control/src/odrive_hardware_interface.cpp
+++ b/odrive_ros2_control/src/odrive_hardware_interface.cpp
@@ -46,7 +46,7 @@ private:
     std::string can_intf_name_;
     SocketCanIntf can_intf_;
     rclcpp::Time timestamp_;
-    osc_interfaces::msg::MotorState generate_motor_state_message();
+    osc_interfaces::msg::MotorState generate_motor_state_message(const rclcpp::Time &  now);
     std::shared_ptr<HwPublisher<osc_interfaces::msg::MotorState>> pub_;
 };
 
@@ -296,7 +296,7 @@ return_type ODriveHardwareInterface::read(const rclcpp::Time& timestamp, const r
     while (can_intf_.read_nonblocking()) {
         // repeat until CAN interface has no more messages
     }
-    osc_interfaces::msg::MotorState msg = generate_motor_state_message();
+    osc_interfaces::msg::MotorState msg = generate_motor_state_message(timestamp);
     pub_->publishData(msg);
     return return_type::OK;
 }
@@ -374,10 +374,9 @@ void ODriveHardwareInterface::set_axis_command_mode(const Axis& axis) {
     axis.send(clear_error_msg);
     axis.send(state_msg);
 }
-osc_interfaces::msg::MotorState ODriveHardwareInterface::generate_motor_state_message() {
-    static rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
+osc_interfaces::msg::MotorState ODriveHardwareInterface::generate_motor_state_message(const rclcpp::Time &  now) {
     osc_interfaces::msg::MotorState msg;
-    msg.header.stamp = clock->now();
+    msg.header.stamp = now;
     msg.motor_type = osc_interfaces::msg::MotorState::MOTOR_TYPE_PROP;
     msg.motor_control_mode = osc_interfaces::msg::MotorState::MOTOR_CONTROL_MODE_VELOCITY; // A MODIFIER POUR ETRE
                                                                                            // DYANMIQUE

--- a/odrive_ros2_control/src/odrive_hardware_interface.cpp
+++ b/odrive_ros2_control/src/odrive_hardware_interface.cpp
@@ -475,30 +475,27 @@ osc_interfaces::msg::MotorsStates ODriveHardwareInterface::generate_motors_state
             motor_msg.command_setpoint = 0.0;
             motor_msg.command_actual = 0.0;
             motor_msg.internal_error = ODRIVE_PROCEDURE_RESULT_MAP.at(axis.procedure_result_);
+        } else if (axis.pos_input_enabled_) {
+            motor_msg.motor_status = osc_interfaces::msg::MotorState::STATUS_RUNNING;
+            motor_msg.motor_control_mode = osc_interfaces::msg::MotorState::CONTROL_MODE_POSITION;
+            motor_msg.command_setpoint = axis.pos_setpoint_;
+            motor_msg.command_actual = axis.pos_estimate_;
+        } else if (axis.vel_input_enabled_) {
+            motor_msg.motor_status = osc_interfaces::msg::MotorState::STATUS_RUNNING;
+            motor_msg.motor_control_mode = osc_interfaces::msg::MotorState::CONTROL_MODE_VELOCITY;
+            motor_msg.command_setpoint = axis.vel_setpoint_;
+            motor_msg.command_actual = axis.vel_estimate_;
+        } else if (axis.torque_input_enabled_) {
+            motor_msg.motor_status = osc_interfaces::msg::MotorState::STATUS_RUNNING;
+            motor_msg.motor_control_mode = osc_interfaces::msg::MotorState::CONTROL_MODE_TORQUE;
+            motor_msg.command_setpoint = axis.torque_setpoint_;
+            motor_msg.command_actual = axis.torque_estimate_;
         } else {
-            if (axis.pos_input_enabled_) {
-                motor_msg.motor_status = osc_interfaces::msg::MotorState::STATUS_RUNNING;
-                motor_msg.motor_control_mode = osc_interfaces::msg::MotorState::CONTROL_MODE_POSITION;
-                motor_msg.command_setpoint = axis.pos_setpoint_;
-                motor_msg.command_actual = axis.pos_estimate_;
-            } else if (axis.vel_input_enabled_) {
-                motor_msg.motor_status = osc_interfaces::msg::MotorState::STATUS_RUNNING;
-                motor_msg.motor_control_mode = osc_interfaces::msg::MotorState::CONTROL_MODE_VELOCITY;
-                motor_msg.command_setpoint = axis.vel_setpoint_;
-                motor_msg.command_actual = axis.vel_estimate_;
-            } else if (axis.torque_input_enabled_) {
-                motor_msg.motor_status = osc_interfaces::msg::MotorState::STATUS_RUNNING;
-                motor_msg.motor_control_mode = osc_interfaces::msg::MotorState::CONTROL_MODE_TORQUE;
-                motor_msg.command_setpoint = axis.torque_setpoint_;
-                motor_msg.command_actual = axis.torque_estimate_;
-            } else {
-                motor_msg.motor_status = osc_interfaces::msg::MotorState::STATUS_IDLE;
-                motor_msg.motor_control_mode = osc_interfaces::msg::MotorState::CONTROL_MODE_IDLE;
-                motor_msg.command_setpoint = 0.0;
-                motor_msg.command_actual = 0.0;
-            }
+            motor_msg.motor_status = osc_interfaces::msg::MotorState::STATUS_IDLE;
+            motor_msg.motor_control_mode = osc_interfaces::msg::MotorState::CONTROL_MODE_IDLE;
+            motor_msg.command_setpoint = 0.0;
+            motor_msg.command_actual = 0.0;
         }
-
         msg.data.push_back(motor_msg);
     }
 


### PR DESCRIPTION
Ajout du simple publisher dans le hardware interface pour publier sur le topic /odrive_state. Un timestamp est utilisé pour comparer le temps actuel et faire la publication du topic à une fréquence de 2 hz.

Dans le read, ajout de la lecture des paramètres suivant: serial number, tension, courant, température, erreurs.

Un check sur le heartbeat avec un timeout de 0.1s permet de valider la connection.

Le message publisé sur le topic est de type MotorState (voir la la PR Feat  health check msg dans osc_interfaces. Le message est populé à l’aide des paramètres lus.

Next steps avant de merger:
- Valider pourquoi le serial number ne se fait jamais populer
- Tester davantage sur le robot pour valider la lecture des données
- Mettre en erreur les odrives et valider
- Déconnecter les odrives et valider

