### PR TITLE
added fallback when unknown code

### DIFF
--- a/odrive_ros2_control/src/odrive_hardware_interface.cpp
+++ b/odrive_ros2_control/src/odrive_hardware_interface.cpp
@@ -499,13 +499,24 @@ osc_interfaces::msg::MotorsStates ODriveHardwareInterface::generate_motors_state
             motor_msg.motor_control_mode = osc_interfaces::msg::MotorState::CONTROL_MODE_IDLE;
             motor_msg.command_setpoint = 0.0;
             motor_msg.command_actual = 0.0;
-            motor_msg.status_detail = ODRIVE_ERROR_MAP.at(axis.error_code_);
+            auto it = ODRIVE_ERROR_MAP.find(axis.error_code_);
+            if (it != ODRIVE_ERROR_MAP.end()) {
+                motor_msg.status_detail = it->second;
+            } else {
+                motor_msg.status_detail = "Unknown Error";
+            }
         } else if (axis.procedure_result_ != PROCEDURE_RESULT_SUCCESS) {
             motor_msg.motor_status = osc_interfaces::msg::DeviceStatus::STATUS_ERROR;
             motor_msg.motor_control_mode = osc_interfaces::msg::MotorState::CONTROL_MODE_IDLE;
             motor_msg.command_setpoint = 0.0;
             motor_msg.command_actual = 0.0;
             motor_msg.status_detail = ODRIVE_PROCEDURE_RESULT_MAP.at(axis.procedure_result_);
+            auto it = ODRIVE_PROCEDURE_RESULT_MAP.find(axis.procedure_result_);
+            if (it != ODRIVE_PROCEDURE_RESULT_MAP.end()) {
+                motor_msg.status_detail = it->second;
+            } else {
+                motor_msg.status_detail = "Unknown State";
+            }
         } else if (axis.axis_state_ != AXIS_STATE_CLOSED_LOOP_CONTROL) {
             motor_msg.motor_status = osc_interfaces::msg::DeviceStatus::STATUS_IDLE;
             motor_msg.motor_control_mode = osc_interfaces::msg::MotorState::CONTROL_MODE_IDLE;


### PR DESCRIPTION
Le field "active error" de Odrive retourne dans certains cas une valeur non existante qui fait "crash" le code avec un throw out of range.

Valeur qui devrait être retourné:
268435456 = 0x10000000

Valeur retourné:
268435457 = 0x10000001

Pour régler ce problème, il y a l'ajout d'un check pour confirmer que la valeur est existante.
Cette même validation a été mise pour la procédure pour éviter qu'un problème similaire arrive.

