### PR TITLE
Feat  odrive firmware update 0.6.11

### DIFF
--- a/odrive_ros2_control/src/odrive_hardware_interface.cpp
+++ b/odrive_ros2_control/src/odrive_hardware_interface.cpp
@@ -534,7 +534,8 @@ osc_interfaces::msg::MotorsStates ODriveHardwareInterface::generate_motors_state
             }
         }
 
-        else if (axis.procedure_result_ != PROCEDURE_RESULT_SUCCESS || PROCEDURE_RESULT_BUSY) {
+        else if (axis.procedure_result_ != PROCEDURE_RESULT_SUCCESS &&
+                axis.procedure_result_ != PROCEDURE_RESULT_BUSY) {
             // Procedure result indicates an error
             motor_msg.motor_status = osc_interfaces::msg::DeviceStatus::STATUS_ERROR;
             motor_msg.motor_control_mode = osc_interfaces::msg::MotorState::CONTROL_MODE_IDLE;

--- a/odrive_ros2_control/src/odrive_hardware_interface.cpp
+++ b/odrive_ros2_control/src/odrive_hardware_interface.cpp
@@ -506,38 +506,48 @@ osc_interfaces::msg::MotorsStates ODriveHardwareInterface::generate_motors_state
         motor_msg.temperature_c = axis.motor_temperature_;
 
         if (axis.error_code_ != ODRIVE_ERROR_NONE) {
+            // Error state
             motor_msg.motor_status = osc_interfaces::msg::DeviceStatus::STATUS_ERROR;
             motor_msg.motor_control_mode = osc_interfaces::msg::MotorState::CONTROL_MODE_IDLE;
             motor_msg.command_setpoint = 0.0;
             motor_msg.command_actual = 0.0;
             motor_msg.status_detail = decode_error(axis.error_code_);
-        } else if (axis.procedure_result_ != PROCEDURE_RESULT_SUCCESS) {
+        } 
+
+        else if (axis.procedure_result_ == PROCEDURE_RESULT_BUSY && 
+                axis.axis_state_ == AXIS_STATE_CLOSED_LOOP_CONTROL) {
+            // Axis is running in closed loop control
+            motor_msg.motor_status = osc_interfaces::msg::DeviceStatus::STATUS_RUNNING;
+            motor_msg.status_detail = ODRIVE_AXIS_STATE_MAP.at(axis.axis_state_);
+            if (axis.pos_input_enabled_) {
+                motor_msg.motor_control_mode = osc_interfaces::msg::MotorState::CONTROL_MODE_POSITION;
+                motor_msg.command_setpoint = axis.pos_setpoint_;
+                motor_msg.command_actual = axis.pos_estimate_;
+            } else if (axis.vel_input_enabled_) {
+                motor_msg.motor_control_mode = osc_interfaces::msg::MotorState::CONTROL_MODE_VELOCITY;
+                motor_msg.command_setpoint = axis.vel_setpoint_;
+                motor_msg.command_actual = axis.vel_estimate_;
+            } else if (axis.torque_input_enabled_) {
+                motor_msg.motor_control_mode = osc_interfaces::msg::MotorState::CONTROL_MODE_TORQUE;
+                motor_msg.command_setpoint = axis.torque_setpoint_;
+                motor_msg.command_actual = axis.torque_estimate_;
+            }
+        }
+
+        else if (axis.procedure_result_ != PROCEDURE_RESULT_SUCCESS || PROCEDURE_RESULT_BUSY) {
+            // Procedure result indicates an error
             motor_msg.motor_status = osc_interfaces::msg::DeviceStatus::STATUS_ERROR;
             motor_msg.motor_control_mode = osc_interfaces::msg::MotorState::CONTROL_MODE_IDLE;
             motor_msg.command_setpoint = 0.0;
             motor_msg.command_actual = 0.0;
             motor_msg.status_detail = ODRIVE_PROCEDURE_RESULT_MAP.at(axis.procedure_result_);
-        } else if (axis.axis_state_ != AXIS_STATE_CLOSED_LOOP_CONTROL) {
+        } else {
+            // Axis is not running in closed loop control
             motor_msg.motor_status = osc_interfaces::msg::DeviceStatus::STATUS_IDLE;
             motor_msg.motor_control_mode = osc_interfaces::msg::MotorState::CONTROL_MODE_IDLE;
             motor_msg.command_setpoint = 0.0;
             motor_msg.command_actual = 0.0;
             motor_msg.status_detail = ODRIVE_AXIS_STATE_MAP.at(axis.axis_state_);
-        } else if (axis.pos_input_enabled_) {
-            motor_msg.motor_status = osc_interfaces::msg::DeviceStatus::STATUS_RUNNING;
-            motor_msg.motor_control_mode = osc_interfaces::msg::MotorState::CONTROL_MODE_POSITION;
-            motor_msg.command_setpoint = axis.pos_setpoint_;
-            motor_msg.command_actual = axis.pos_estimate_;
-        } else if (axis.vel_input_enabled_) {
-            motor_msg.motor_status = osc_interfaces::msg::DeviceStatus::STATUS_RUNNING;
-            motor_msg.motor_control_mode = osc_interfaces::msg::MotorState::CONTROL_MODE_VELOCITY;
-            motor_msg.command_setpoint = axis.vel_setpoint_;
-            motor_msg.command_actual = axis.vel_estimate_;
-        } else if (axis.torque_input_enabled_) {
-            motor_msg.motor_status = osc_interfaces::msg::DeviceStatus::STATUS_RUNNING;
-            motor_msg.motor_control_mode = osc_interfaces::msg::MotorState::CONTROL_MODE_TORQUE;
-            motor_msg.command_setpoint = axis.torque_setpoint_;
-            motor_msg.command_actual = axis.torque_estimate_;
         }
         msg.data.push_back(motor_msg);
     }


### PR DESCRIPTION
Ajustement de la logique d'état des odrives pour considérer le nouvel état du firmware update:

axis0.procedure_result is now reported as ProcedureResult.BUSY during AxisState.CLOSED_LOOP_CONTROL. This makes it consistent with other states. Previously, it was left unchanged when entering AxisState.CLOSED_LOOP_CONTROL and would therefore report the result of the previous state, unless clear_errors() was called.